### PR TITLE
Fix climate model and set it to auto publish

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -79,39 +79,39 @@ jobs:
         password: ${{ secrets.DAFNI_SERVICE_ACCOUNT_PASSWORD }}
         version-message: "Uploaded from GitHub workflow"
         parent-model: "da6d001a-d58e-4931-8e9f-af653e5f14f1"
-publish-uk-climate-analysis-image:
-  name: Publish UK Climate Analysis Image
-  runs-on: ubuntu-latest
-  steps:
-  -
-    name: Checkout code
-    uses: actions/checkout@v2
-  -
-    name: DockerBuild
-    uses: docker/build-push-action@v1
-    with:
-      dockerfile: uk-climate-analysis/Dockerfile
-      path: ./uk-climate-analysis
-      username: dafni-service-account
-      password: ${{ secrets.SERVICE_ACCOUNT }}
-      registry: ghcr.io
-      repository: dafnifacility/uk-climate-analysis
-      tags: latest
-      tag_with_sha: true
-      tag_with_ref: true
-  -
-    name: Compress docker image
-    run: |
-      docker build -t uk-climate-analysis ./uk-climate-analysis/
-      docker save -o uk-climate-analysis.tar uk-climate-analysis:latest
-      gzip uk-climate-analysis.tar
-  -
-    name: Upload To DAFNI
-    uses: dafnifacility/dafni-model-uploader@v1.9
-    with:
-      definition-path: ./uk-climate-analysis/model_definition.yaml
-      image-path: ./uk-climate-analysis.tar.gz
-      username: model-uploader
-      password: ${{ secrets.DAFNI_SERVICE_ACCOUNT_PASSWORD }}
-      version-message: "Uploaded from GitHub workflow"
-      parent-model: "d6f7b327-0418-4de6-bf8b-add2555f9547"
+  publish-uk-climate-analysis-image:
+    name: Publish UK Climate Analysis Image
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout code
+      uses: actions/checkout@v2
+    -
+      name: DockerBuild
+      uses: docker/build-push-action@v1
+      with:
+        dockerfile: uk-climate-analysis/Dockerfile
+        path: ./uk-climate-analysis
+        username: dafni-service-account
+        password: ${{ secrets.SERVICE_ACCOUNT }}
+        registry: ghcr.io
+        repository: dafnifacility/uk-climate-analysis
+        tags: latest
+        tag_with_sha: true
+        tag_with_ref: true
+    -
+      name: Compress docker image
+      run: |
+        docker build -t uk-climate-analysis ./uk-climate-analysis/
+        docker save -o uk-climate-analysis.tar uk-climate-analysis:latest
+        gzip uk-climate-analysis.tar
+    -
+      name: Upload To DAFNI
+      uses: dafnifacility/dafni-model-uploader@v1.9
+      with:
+        definition-path: ./uk-climate-analysis/model_definition.yaml
+        image-path: ./uk-climate-analysis.tar.gz
+        username: model-uploader
+        password: ${{ secrets.DAFNI_SERVICE_ACCOUNT_PASSWORD }}
+        version-message: "Uploaded from GitHub workflow"
+        parent-model: "d6f7b327-0418-4de6-bf8b-add2555f9547"

--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -79,3 +79,39 @@ jobs:
         password: ${{ secrets.DAFNI_SERVICE_ACCOUNT_PASSWORD }}
         version-message: "Uploaded from GitHub workflow"
         parent-model: "da6d001a-d58e-4931-8e9f-af653e5f14f1"
+publish-uk-climate-analysis-image:
+  name: Publish UK Climate Analysis Image
+  runs-on: ubuntu-latest
+  steps:
+  -
+    name: Checkout code
+    uses: actions/checkout@v2
+  -
+    name: DockerBuild
+    uses: docker/build-push-action@v1
+    with:
+      dockerfile: uk-climate-analysis/Dockerfile
+      path: ./uk-climate-analysis
+      username: dafni-service-account
+      password: ${{ secrets.SERVICE_ACCOUNT }}
+      registry: ghcr.io
+      repository: dafnifacility/uk-climate-analysis
+      tags: latest
+      tag_with_sha: true
+      tag_with_ref: true
+  -
+    name: Compress docker image
+    run: |
+      docker build -t uk-climate-analysis ./uk-climate-analysis/
+      docker save -o uk-climate-analysis.tar uk-climate-analysis:latest
+      gzip uk-climate-analysis.tar
+  -
+    name: Upload To DAFNI
+    uses: dafnifacility/dafni-model-uploader@v1.9
+    with:
+      definition-path: ./uk-climate-analysis/model_definition.yaml
+      image-path: ./uk-climate-analysis.tar.gz
+      username: model-uploader
+      password: ${{ secrets.DAFNI_SERVICE_ACCOUNT_PASSWORD }}
+      version-message: "Uploaded from GitHub workflow"
+      parent-model: "d6f7b327-0418-4de6-bf8b-add2555f9547"

--- a/uk-climate-analysis/post_processing.py
+++ b/uk-climate-analysis/post_processing.py
@@ -13,15 +13,15 @@ def define_months(df: DataFrame, season: str) -> DataFrame:
 
 
 def define_threshold(df: DataFrame, season: str, feature: str) -> DataFrame:
-    threshold_df = df
-
+    if feature == "sunshine" or feature == "snow-falling":
+        return df
     if season == "winter":
-        threshold_df = df.loc[(df["Values"] >= 10)]
-    if season == "summer":
-        threshold_df = df.loc[(df["Values"] <= 1)]
+        return df.loc[(df["Values"] >= 10)]
+    if season == "summer" and feature == "rainfall":
+        return df.loc[(df["Values"] <= 1)]
     if season == "summer" and feature == "maximum-temperature":
-        threshold_df = df.loc[(df["Values"] >= 18)]
-    return threshold_df
+        return df.loc[(df["Values"] >= 18)]
+    return df
 
 
 def get_prediction_data(df: DataFrame, feature: str) -> DataFrame:


### PR DESCRIPTION
The current implementation of the climate model has a couple logic bugs compared to the original version. For example, all values for summer (except maximum-temperature) would not be tallied as the logic had been configured for rainfall, which has a much lower threshold than the other features. This fix brings it back in line with the original logic flow.

In addition, the uk-climate-analysis model has been added to `dockerbuild.yml` in order to auto-publish it with the update to the master branch.