### PR TITLE
Update IntMaps.ipynb, fixed typo

### DIFF
--- a/MapVisualisationExample-WW2Cargo/IntMaps.ipynb
+++ b/MapVisualisationExample-WW2Cargo/IntMaps.ipynb
@@ -14,7 +14,7 @@
     "except:\n",
     "    !pip install plotly\n",
     "try:\n",
-    "    import impywidgets\n",
+    "    import ipywidgets\n",
     "except:\n",
     "    !pip install ipywidgets"
    ]


### PR DESCRIPTION
Fixed typo (doesn't actually impact much - fixing just stops !pip install being fired every time).