### PR TITLE
fix: Correct spelling of licence [CORE-3424]

### DIFF
--- a/matlab-hello-world-model/model_definition.yaml
+++ b/matlab-hello-world-model/model_definition.yaml
@@ -8,7 +8,7 @@ metadata:
   contact_point_email: info@dafni.ac.uk
   summary: A hello world model using Matlab
   description: A hello world model using Matlab
-  license: https://creativecommons.org/licenses/by/4.0/
+  licence: https://creativecommons.org/licenses/by/4.0/
   rights: open
 spec:
   inputs:

--- a/simple-example--fibonacci-model/model_definition.yaml
+++ b/simple-example--fibonacci-model/model_definition.yaml
@@ -11,7 +11,7 @@ metadata:
     An example Model designed for use with DAFNI.
 
     This generates a Fibonacci sequence and saves it to a json file.
-  license: https://creativecommons.org/licenses/by/4.0/
+  licence: https://creativecommons.org/licenses/by/4.0/
   rights: open
 spec:
   inputs:

--- a/tiny-example--hello-world-model/model_definition.yaml
+++ b/tiny-example--hello-world-model/model_definition.yaml
@@ -10,7 +10,7 @@ metadata:
   description: >
     A tiny example Model designed for use with DAFNI. This outputs a txt file with "Hello $NAME" where $NAME is a
     configurable input to the Model. $NAME defaults to "World".
-  license: https://creativecommons.org/licenses/by/4.0/
+  licence: https://creativecommons.org/licenses/by/4.0/
   rights: open
 spec:
   inputs:


### PR DESCRIPTION
A follow on from https://github.com/dafnifacility/dafni-example-models/pull/40/. When we corrected the spelling of 'license' in the NID, we forgot to correct it here as well. 