### PR TITLE
Updated MNIST example: now saves ANN (trained) file

### DIFF
--- a/TensorflowExample/test-MNIST.py
+++ b/TensorflowExample/test-MNIST.py
@@ -63,6 +63,13 @@ model.compile(optimizer='adam',
 history = model.fit(train_images, train_labels, epochs=10)
 print(history.history.keys())
 
+# Save Model to file (contains weights, config, comp.inf. etc.)
+mod_sfp = os.path.join(gPATHO, "MNIST_model.keras")
+model.save(mod_sfp)
+
+# This model datafile can be loaded using the line of code below
+# model_ld = tf.keras.models.load_model(mod_sfp)
+
 fig, ax = plt.subplots(figsize=(8, 6))
 ax.plot(history.history['loss'], label='Loss fn')
 ax.plot(history.history['accuracy'], label='Accuracy')

--- a/TensorflowExample/test-mlgpu.yaml
+++ b/TensorflowExample/test-mlgpu.yaml
@@ -33,3 +33,8 @@ spec:
         type: png
         description: >
           A png graph showing image classification predictions (tensorflow)
+      - name: MNIST_model.keras
+        type: keras
+        description: >
+         This is the model file for the ANN containing the network weights, structure etc. 
+         This can be loaded into a program and then used without the need for any further training.


### PR DESCRIPTION
Add: Save the Tensorflow model file (containing ANN weights/config etc.) as per Jen's suggestion.
